### PR TITLE
fix: WS2812 does not have a separate white channel

### DIFF
--- a/packages/light-nano-c6.yaml
+++ b/packages/light-nano-c6.yaml
@@ -6,7 +6,6 @@ light:
     num_leds: 1
     # rmt_channel: 0 ### this stopped working 2025/02
     chipset: WS2812
-    is_rgbw: true
     id: m5stack_led
     name: "Light"
     icon: "mdi:led-outline"


### PR DESCRIPTION
Ref: https://github.com/m5stack/M5NanoC6/blob/main/examples/Basic/rgb_led/rgb_led.ino
Ref: https://shop.m5stack.com/products/m5stack-nanoc6-dev-kit
Ref: https://docs.m5stack.com/en/core/M5NanoC6